### PR TITLE
locationのヒット順序を修正する

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -15,12 +15,6 @@ server {
 		index index.html index.htm;
 	}
 
-	location ~* ^/[^/]+/[0-9\.]+(\-[^/]+)?/.* {
-		if ($request_uri !~ "^/[^/]+/[0-9\.]+(\-[^/]+)?/(css|fonts|js)/.*") {
-			return 404;
-		}
-	}
-
 	location ~* \.(css|js)$ {
 		gzip on;
 		gzip_http_version 1.1;
@@ -41,5 +35,11 @@ server {
 		add_header 'Access-Control-Allow-Headers' 'Content-Type,Accept';
 		add_header 'Access-Control-Allow-Method' 'GET, POST, OPTIONS, PUT, DELETE';
 		break;
+	}
+
+	location ~* ^/[^/]+/[0-9\.]+(\-[^/]+)?/.* {
+		if ($request_uri !~ "^/[^/]+/[0-9\.]+(\-[^/]+)?/(css|fonts|js)/.*") {
+			return 404;
+		}
 	}
 }


### PR DESCRIPTION
## 概要

> glyphicon使おうとするとCORSで弾かれてつらい

<cite>https://twitter.com/428rinsuki/status/922868012935348224</cite>

## 原因

CDN 配信コンテンツにアクセスすると、 `location /` の次に書かれた、CDN 配信コンテンツとは関係ないコンテンツの応答を404にするための location 定義に引っかかり、それ以降に記述された location 定義が実行されていなかった

## やったこと

* CDN 配信コンテンツとは関係ないコンテンツの応答を404にするための location 定義を最後に持ってくる